### PR TITLE
Add ping tests for multiple assets

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,8 @@
 GF_SECURITY_ADMIN_USER="cks" # username for logging into Grafana
 GF_SECURITY_ADMIN_PASSWORD="pass" # password for logging into Grafana
 BASIC_AUTH_PASSWORD="pass" # password for basic auth used by Prometheus and Pushgateway
+BASIC_AUTH_WEBSITE_USERNAME="preview" # username for basic auth used in our websites
+BASIC_AUTH_WEBSITE_PASSWORD="123NewCKEditorSite" # password for basic auth used in our websites
 
 PUSHGATEWAY_URL="http://pushgateway:9091"
 PROMETHEUS_URL="http://prometheus:9090"

--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,6 @@
 GF_SECURITY_ADMIN_USER="cks" # username for logging into Grafana
 GF_SECURITY_ADMIN_PASSWORD="pass" # password for logging into Grafana
 BASIC_AUTH_PASSWORD="pass" # password for basic auth used by Prometheus and Pushgateway
-BASIC_AUTH_WEBSITE_USERNAME="preview" # username for basic auth used in our websites
-BASIC_AUTH_WEBSITE_PASSWORD="123NewCKEditorSite" # password for basic auth used in our websites
 
 PUSHGATEWAY_URL="http://pushgateway:9091"
 PROMETHEUS_URL="http://prometheus:9090"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,15 +10,14 @@ import Metrics from './Metrics';
 import { ITest } from './tests/Test';
 import PingSiteTest from './tests/common/PingSiteTest';
 
+import { pingSiteData } from './sitesToTest';
+
 const APPLICATION_NAME: string = 'cksource-monitoring';
 const PUSHGATEWAY_URL: string = process.env.PUSHGATEWAY_URL ?? 'http://pushgateway:9091';
 
-const TESTS: ITest[] = [
-	new PingSiteTest( 'https://ckeditor.com/' ),
-	new PingSiteTest( 'https://cksource.com/' ),
-	new PingSiteTest( 'https://onlinehtmleditor.dev/' ),
-	new PingSiteTest( 'https://onlinemarkdowneditor.dev/' )
-];
+// Generate the tests set that will be executed by the test runner.
+const TESTS: ITest[] = _getTestsDefinition();
+
 const metrics: Metrics = new Metrics();
 const testRunner: TestsRunner = new TestsRunner( metrics, TESTS );
 
@@ -67,3 +66,23 @@ async function _getBasicAuthPassword(): Promise<string> {
 
 	return secret;
 }
+
+function _getTestsDefinition(): ITest[] {
+	const TESTS_DEFINITION: ITest[] = [];
+
+	// Create ping site tests.
+	let basicAuth: boolean = false;
+
+	for ( const siteCategory in pingSiteData ) {
+		pingSiteData[ siteCategory ].forEach( siteUrl => {
+			if ( siteCategory === 'basicAuth' ) {
+				basicAuth = true;
+			}
+
+			TESTS_DEFINITION.push( new PingSiteTest( siteUrl, basicAuth ) );
+		} );
+	}
+
+	return TESTS_DEFINITION;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,16 +71,8 @@ function _getTestsDefinition(): ITest[] {
 	const TESTS_DEFINITION: ITest[] = [];
 
 	// Create ping site tests.
-	let basicAuth: boolean = false;
-
 	for ( const siteCategory in pingSiteData ) {
-		pingSiteData[ siteCategory ].forEach( siteUrl => {
-			if ( siteCategory === 'basicAuth' ) {
-				basicAuth = true;
-			}
-
-			TESTS_DEFINITION.push( new PingSiteTest( siteUrl, basicAuth ) );
-		} );
+		pingSiteData[ siteCategory ].forEach( siteUrl => TESTS_DEFINITION.push( new PingSiteTest( siteUrl ) ) );
 	}
 
 	return TESTS_DEFINITION;

--- a/src/sitesToTest.ts
+++ b/src/sitesToTest.ts
@@ -21,13 +21,14 @@ const pingSiteData: Record<string, string[]> = {
 	CDNs: [
 		'https://cdn.ckeditor.com/',
 		'https://download.cksource.com/',
-		'https://cdn.ckbox.io/ckbox/latest/ckbox.js',
-		'https://download.ckbox.io/ckbox/ckbox_2.4.0.zip'
+		'https://cdn.ckbox.io/healthz.html',
+		'https://download.ckbox.io/healthz.html'
 	],
 	internalCDNs: [
 		'https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/index.html',
 		'https://builder.ckeditor-dev.com/ckeditor-5/builder/',
-		'https://builder-nightly.ckeditor-dev.com/ckeditor-5/builder/'
+		'https://builder-nightly.ckeditor-dev.com/ckeditor-5/builder/',
+		'https://builder-demo.ckeditor-dev.com/ckeditor-5/builder/'
 	],
 	internalTools: [
 		'https://cla.tiny.cloud/tiny/img/cla-workflow.png',
@@ -43,10 +44,6 @@ const pingSiteData: Record<string, string[]> = {
 		'https://qa-automation.internal.cke-cs-dev.com/health',
 		'https://hanghub.cksource.com/healthz',
 		'https://cs-framework-docs.internal.cke-cs-dev.com/healthz'
-	],
-	basicAuth: [
-		'https://portal-storybook.ckeditor-dev.com/',
-		'https://ckbox-storybook.cke-cs-dev.com/'
 	]
 };
 

--- a/src/sitesToTest.ts
+++ b/src/sitesToTest.ts
@@ -1,0 +1,53 @@
+/*
+ Copyright (c), CKSource Holding sp. z o.o. All rights reserved.
+ */
+const pingSiteData: Record<string, string[]> = {
+	websites: [
+		'https://ckeditor.com/',
+		'https://cksource.com/',
+		'https://onlinehtmleditor.dev/',
+		'https://onlinemarkdowneditor.dev/'
+	],
+	ckeditorOrigins: [
+		'https://ckeditor.com/docs/',
+		'https://ckeditor.com/ckeditor-5/builder/',
+		'https://ckeditor.com/cke4/addons/plugins/all',
+		'https://ckeditor.com/docs/ckfinder/ckfinder3/',
+		'https://origin.ckeditor.com/old/forums',
+		'https://ckeditor.com/ckfinder/demo/',
+		'https://ckeditor.com/partners/',
+		'https://ckeditor.com/technology-partners'
+	],
+	CDNs: [
+		'https://cdn.ckeditor.com/',
+		'https://download.cksource.com/',
+		'https://cdn.ckbox.io/ckbox/latest/ckbox.js',
+		'https://download.ckbox.io/ckbox/ckbox_2.4.0.zip'
+	],
+	internalCDNs: [
+		'https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/index.html',
+		'https://builder.ckeditor-dev.com/ckeditor-5/builder/',
+		'https://builder-nightly.ckeditor-dev.com/ckeditor-5/builder/'
+	],
+	internalTools: [
+		'https://cla.tiny.cloud/tiny/img/cla-workflow.png',
+		'https://cla.ckeditor.com/cksource/img/cla-workflow.png',
+		'https://buttercms-ai-proxy.internal.cke-cs-dev.com/health/liveliness',
+		'https://buttercms-ai-proxy.internal.cke-cs.com/health/liveliness',
+		'https://builder-api.internal.cke-cs-dev.com/healthz/live',
+		'https://builder-api.ckeditor.com/healthz/live',
+		'https://zenhub-integration.internal.cke-cs-dev.com/',
+		'https://merge-branches.internal.cke-cs-dev.com/',
+		'https://docs-builder.internal.cke-cs-dev.com/favicon.ico',
+		'https://scrum-poker.internal.cke-cs-dev.com/',
+		'https://qa-automation.internal.cke-cs-dev.com/health',
+		'https://hanghub.cksource.com/healthz',
+		'https://cs-framework-docs.internal.cke-cs-dev.com/healthz'
+	],
+	basicAuth: [
+		'https://portal-storybook.ckeditor-dev.com/',
+		'https://ckbox-storybook.cke-cs-dev.com/'
+	]
+};
+
+export { pingSiteData };

--- a/src/tests/common/PingSiteTest.ts
+++ b/src/tests/common/PingSiteTest.ts
@@ -13,8 +13,7 @@ class PingSiteTest implements ITest {
 	public testName: string = 'ping';
 
 	public constructor(
-		private readonly _address: string,
-		private readonly _basicAuth: boolean
+		private readonly _address: string
 	) {
 		const parsedUrl: URL = new URL( this._address );
 
@@ -22,26 +21,13 @@ class PingSiteTest implements ITest {
 	}
 
 	public async run(): Promise<void> {
-		const headers: { Authorization?: string; } = {};
-
-		if ( this._basicAuth ) {
-			headers.Authorization = `Basic ${ this._getWebsiteBasicAuth() }`;
-		}
-
-		const httpResponse: Response = await fetch( this._address, { headers } );
+		const httpResponse: Response = await fetch( this._address );
 
 		const statusCode: number = httpResponse.status;
 
 		if ( statusCode > 399 ) {
 			throw new RequestFailError( httpResponse.status, await httpResponse.text() );
 		}
-	}
-
-	private _getWebsiteBasicAuth(): string {
-		const user: string | undefined = process.env.BASIC_AUTH_WEBSITE_USERNAME;
-		const password: string | undefined = process.env.BASIC_AUTH_WEBSITE_PASSWORD;
-
-		return Buffer.from( user + ':' + password, 'binary' ).toString( 'base64' );
 	}
 }
 

--- a/src/tests/common/PingSiteTest.ts
+++ b/src/tests/common/PingSiteTest.ts
@@ -13,10 +13,10 @@ class PingSiteTest implements ITest {
 	public testName: string = 'ping';
 
 	public constructor(
-		public address: string,
+		private readonly _address: string,
 		private readonly _basicAuth: boolean
 	) {
-		const parsedUrl: URL = new URL( this.address );
+		const parsedUrl: URL = new URL( this._address );
 
 		this.productName = parsedUrl.host + parsedUrl.pathname;
 	}
@@ -28,7 +28,7 @@ class PingSiteTest implements ITest {
 			headers.Authorization = `Basic ${ this._getWebsiteBasicAuth() }`;
 		}
 
-		const httpResponse: Response = await fetch( this.address, { headers } );
+		const httpResponse: Response = await fetch( this._address, { headers } );
 
 		const statusCode: number = httpResponse.status;
 

--- a/src/tests/common/PingSiteTest.ts
+++ b/src/tests/common/PingSiteTest.ts
@@ -28,7 +28,7 @@ class PingSiteTest implements ITest {
 			headers.Authorization = `Basic ${ this._getWebsiteBasicAuth() }`;
 		}
 
-		const httpResponse: Response = await fetch( this.address, { method: 'HEAD', headers } );
+		const httpResponse: Response = await fetch( this.address, { headers } );
 
 		const statusCode: number = httpResponse.status;
 


### PR DESCRIPTION
Closes #15 

Follow-ups:
- Some endpoints don't support the `HEAD` request method, so these changes use only `GET`. In order to optimize the tests, we can use `HEAD` and verify the `Content-Length` header
- Grafana dashboard needs to be updated to represent the data in a more friendly way