### PR TITLE
chore: Add static target for ButterCMS exporter

### DIFF
--- a/infrastructure/prometheus/prometheus.yml
+++ b/infrastructure/prometheus/prometheus.yml
@@ -13,3 +13,15 @@ scrape_configs:
       - targets: ['pushgateway:9091']
         labels:
           service: 'pushgateway'
+  - job_name: buttercms-postgres-exporter
+    metrics_path: /metrics
+    scheme: https
+    # Can be slow as it connects to different infrastructure
+    scrape_timeout: 5s
+    basic_auth:
+      username: cks
+      password_file: "/etc/prometheus/password"
+    static_configs:
+      - targets: ['buttercms-postgres-exporter.internal.cke-cs-dev.com']
+        labels:
+          service: 'buttercms-postgres-exporter'


### PR DESCRIPTION
## Changelog

```
chore: Add static target for ButterCMS exporter

Create a scrape target in prometheus configuration to handle receiving
metrics from ButterCMS production database. The new target is a postgres
exporter running in our infrastructure.

Touches: cksource/cs#19411
```

## Linked issues

-   Closes: #0.
-   Touches: cksource/cs#19411
